### PR TITLE
updated a url and removed Peel

### DIFF
--- a/docs/hpc/04_datasets/01_intro.md
+++ b/docs/hpc/04_datasets/01_intro.md
@@ -92,7 +92,7 @@ Please open the ImageNet site, find the terms of use ([http://image-net.org/down
 
 NYU has a subscription to Twitter Decahose - 10% random sample of the realtime Twitter Firehose through a streaming connection
 
-*Data are stored* in GCP cloud (BigQuery) and on the HPC cluster Greene.
+*Datasets are stored* in GCP cloud (BigQuery) and on the HPC cluster Greene.
 
 Please contact Megan Brown at [The Center for Social Media & Politics](https://csmapnyu.org/) to get access to data and learn the tools available to work with it.
 


### PR DESCRIPTION
Just a couple of minor updates.

I removed a reference to Peel and updated the URL for the ProQuest Congressional Record.  It was giving a 404.

Please let me know if you see anything I've missed or recommend any other changes.
