### PR TITLE
changed from rm to mv when making link from scratch to home

### DIFF
--- a/docs/hpc/03_storage/05_best_practices.mdx
+++ b/docs/hpc/03_storage/05_best_practices.mdx
@@ -41,23 +41,19 @@ As mentioned elsewhere in our documentation, a problem we often see for our user
 
 Our recommended fix for this is to make a directory for these files in your `/scratch` directory and then make a symbolic link in your `/home` that points to the one you just created in `/scratch`.  This allows these applications to write to what appears to be your `/home` directory, but is actually stored in your `/scratch` directory.  This can be accomplished with the following commands:
 
-:::warning
-The first part of the following commands will remove the contents of the dot directory in your `${HOME}` directory.  Be sure to copy anything you'd like to save from that directory before executing.
-:::
-
 For VSCode:
 ```bash
-rm -rf ${HOME}/.vscode-server && mkdir -p ${SCRATCH}/vscode-server && ln -s ${SCRATCH}/vscode-server ${HOME}/.vscode-server
+mv ${HOME}/.vscode-server ${SCRATCH}/.vscode-server && ln -s ${SCRATCH}/.vscode-server ${HOME}/.vscode-server
 ```
 
 For Cursor:
 ```bash
-rm -rf ${HOME}/.cursor-server && mkdir -p ${SCRATCH}/cursor-server && ln -s ${SCRATCH}/cursor-server ${HOME}/.cursor-server
+mv ${HOME}/.cursor-server ${SCRATCH}/.cursor-server && ln -s ${SCRATCH}/.cursor-server ${HOME}/.cursor-server
 ```
 
 For RStudio:
 ```bash
-rm -rf ${HOME}/.local/share/rstudio && mkdir -p ${SCRATCH}/.local/share/rstudio && ln -s ${SCRATCH}/.local/share/rstudio ${HOME}/.local/share/rstudio
+mv ${HOME}/.local/share/rstudio ${SCRATCH}/.local/share/rstudio && ln -s ${SCRATCH}/.local/share/rstudio ${HOME}/.local/share/rstudio
 ```
 
 For details about changing your default RStudio directory please see [User state storage](https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/workspace_management.html#user-state-storage).


### PR DESCRIPTION
Was just looking at an email Michael wrote making the link from scratch to home and saw him do it this way.   I like it better than the removal in these instructions.  Less likely for a user to make a mistake and delete something they didn't intend to.